### PR TITLE
fix(types): align TypeScript types with existing runtime array support for `input` in Context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,21 +3,21 @@ import { Options, DocumentObject } from './types'
 import { JsonApiSerializerError } from './errors'
 
 export type Context<TEntity, TExtraProperties = unknown> = {
-  input: TEntity | undefined
+  input: TEntity | TEntity[] | undefined
   transformer: Transformer<TEntity, TExtraProperties>
   included: boolean
   options: Options<TExtraProperties>
 }
 
 export class ContextBuilder<TEntity, TExtraProperties = unknown> {
-  input?: TEntity
+  input?: TEntity | TEntity[]
   transformer?: Transformer<TEntity, TExtraProperties>
   included = false
   options?: Options<TExtraProperties>
 
   constructor(protected renderFunction: (c: Context<TEntity, TExtraProperties>) => DocumentObject) {}
 
-  withInput(input: TEntity) {
+  withInput(input: TEntity | TEntity[]) {
     this.input = input
     return this
   }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -136,7 +136,7 @@ function serializeEntity<TEntity, TExtraOptions>(
 }
 
 function serializeRelation<TEntity = unknown, TExtraOptions = unknown>(
-  context: Context<TEntity, TExtraOptions>,
+  context: Context<TEntity, TExtraOptions> & { input: TEntity },
   includedByType: IncludedRecord,
 ): ResourceIdentifierObject | undefined | null {
   const { input: entity, options, transformer, included } = context


### PR DESCRIPTION
### Problem
The `ContextBuilder.withInput()` method was typed to accept only single entities `TEntity`, but the implementation already supported arrays. This caused TypeScript compilation errors when trying to pass arrays to `withInput()`, even though the runtime code handled arrays correctly.

### Changes made
1. Changed `input` property from `TEntity | undefined` to `TEntity | TEntity[] | undefined` in the `Context` type.
This reflects the actual runtime behavior where input can be either a single entity or an array

2. Added intersection type constraint: `Context<TEntity, TExtraOptions> & { input: TEntity }`
This ensures `serializeRelation` always receives a single entity (never an array). 
The runtime implementation in `serializeContext()` already handles arrays as you can see at [serializer.ts#L98-L108](https://github.com/jsonapiworld/jsonapi-serializer/blob/master/src/serializer.ts#L98-L108):
```typescript
    if (Array.isArray(context.input)) {
      relationships[relation] = {
        data: context.input
          .map((inputItem) => serializeRelation({ ...context, input: inputItem }, includedByType))
          .filter((identifier) => !!identifier) as ResourceIdentifierObject[],
      }
    } else if (context.input !== undefined) {
      relationships[relation] = {
        data: serializeRelation(context, includedByType) as ResourceIdentifierObject,
      }
    }
```

When arrays are processed, they are mapped to individual items before calling `serializeRelation`.
___
All existing functionality remains unchanged. It's only a TypeScript typing improvement.

